### PR TITLE
Add a simple page title

### DIFF
--- a/frontend/src/routes/login/+layout.svelte
+++ b/frontend/src/routes/login/+layout.svelte
@@ -1,3 +1,0 @@
-<svelte:head>
-  <title>Login - Dionysus</title>
-</svelte:head>

--- a/frontend/src/routes/login/+page.svelte
+++ b/frontend/src/routes/login/+page.svelte
@@ -87,6 +87,10 @@
   setTimeout(titleUpdater, 5000 + Math.random() * 5000);
 </script>
 
+<svelte:head>
+  <title>Login - Dionysus</title>
+</svelte:head>
+
 <main
   class="flex flex-col items-center justify-center min-h-screen bg-[#1e1e1e] text-gray-100 p-4"
 >


### PR DESCRIPTION
Fixes #37. This adds a very basic page title; "Dionysus". When we allow for multiple files this should be improved to include those file names. It's different on the login page, where it features a "Login - " prefix.