### PR TITLE
Add spellcheck

### DIFF
--- a/frontend/src/lib/editor/Editor.svelte
+++ b/frontend/src/lib/editor/Editor.svelte
@@ -82,6 +82,7 @@
             },
           ]),
           EditorView.lineWrapping,
+          EditorView.contentAttributes.of({ spellcheck: "true" }),
           basicSetup,
         ],
       }),


### PR DESCRIPTION
Fix #40. Adds builtin support for spellcheck in codemirror which uses the user's browser dictionary. As long as the browser supports multiple languages it's no problem for codemirror, which at least Firefox does.