### PR TITLE
Add docker build check on PR

### DIFF
--- a/.github/workflows/docker-build-on-push.yml
+++ b/.github/workflows/docker-build-on-push.yml
@@ -1,0 +1,27 @@
+name: Build Check on PR
+
+on:
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build_test:
+    name: Test Docker Build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          load: false
+          no-cache: true


### PR DESCRIPTION
Adds a GitHub action which checks that we can build the Docker image when pushing a PR to main. Fixes #65.