### PR TITLE
Add  logging to the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ For production deployments, use the published Docker image and configure it as d
 | database.url | Yes | postgresql://USER:PWD@HOST:PORT/DB |
 | oidc.external_base_url | Yes | Base for externally reachable url. E.g. "https://your-domain.com" |
 | oidc.providers.<name> | Yes | See [OIDC provider config](#oidc-providers-config) section |
-| logging.filter | No | Default: "info,tower_http=debug" |
-| logging.json | No | Default: False |
+| logging.filter | No | [`tracing_subscriber` env-filter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) directive. Default: "info" |
+| logging.json | No | Emit logs as JSON. Default: true |
 | listener.ip | No | Default: 0.0.0.0 (listen everywhere) |
 | listener.port | No | Default: 8000 |
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For production deployments, use the published Docker image and configure it as d
 | database.url | Yes | postgresql://USER:PWD@HOST:PORT/DB |
 | oidc.external_base_url | Yes | Base for externally reachable url. E.g. "https://your-domain.com" |
 | oidc.providers.<name> | Yes | See [OIDC provider config](#oidc-providers-config) section |
-| logging.filter | No | [`tracing_subscriber` env-filter](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/filter/struct.EnvFilter.html) directive. Default: "info" |
+| logging.filter | No | [`tracing_subscriber` env-filter](https://docs.rs/tracing-subscriber/0.3.23/tracing_subscriber/filter/struct.EnvFilter.html) directive. Default: "info" |
 | logging.json | No | Emit logs as JSON. Default: true |
 | listener.ip | No | Default: 0.0.0.0 (listen everywhere) |
 | listener.port | No | Default: 8000 |

--- a/backend/config/default.toml
+++ b/backend/config/default.toml
@@ -1,7 +1,12 @@
+# Built into the binary as the base config layer. Values here are the
+# production defaults. Override per-environment via /etc/dionysus/config.toml,
+# DIONYSUS_CONFIG, or DIONYSUS_ env vars. See README.md for more information.
+# See backend/config/dev.toml for local development overrides.
+
 [listener]
 ip = "0.0.0.0"
 port = "8000"
 
 [logging]
-filter = "info,tower_http=debug"
-json = false
+filter = "info"
+json = true

--- a/backend/config/dev.toml
+++ b/backend/config/dev.toml
@@ -1,3 +1,11 @@
+# Local development overrides. Layered on top of the binary's default.toml.
+# Wired up by compose.yml, for a bare `cargo run`,
+# point DIONYSUS_CONFIG at this file.
+
+[logging]
+filter = "info,backend=debug,tower_http=debug"
+json = false
+
 [oidc]
 external_base_url = "http://localhost:8000"
 

--- a/backend/src/auth.rs
+++ b/backend/src/auth.rs
@@ -82,14 +82,17 @@ impl AuthManager {
         self.sessions.get(session_id).await
     }
 
+    #[tracing::instrument(skip_all)]
     pub async fn logout(&self, session_id: &str) {
         self.sessions.remove(session_id).await;
+        tracing::info!("session logged out");
     }
 
     pub fn provider_ids(&self) -> Vec<String> {
         self.oidc.provider_ids()
     }
 
+    #[tracing::instrument(skip_all, fields(provider_id = %provider_id))]
     pub async fn start_login(&self, provider_id: &str) -> Result<String, AuthError> {
         let provider = self
             .oidc
@@ -130,10 +133,12 @@ impl AuthManager {
             )
             .await;
 
+        tracing::info!("login redirect issued");
         Ok(auth_url.to_string())
     }
 
     /// The [`String`] returned is the session id for the completed login.
+    #[tracing::instrument(skip_all, fields(provider_id = %provider_id))]
     pub async fn finish_login(
         &self,
         provider_id: &str,
@@ -162,7 +167,7 @@ impl AuthManager {
             .request_async(async_http_client)
             .await
             .map_err(|e| {
-                tracing::error!("token exhange failure {e:?}");
+                tracing::warn!(error = %e, "OIDC token exchange failed");
                 AuthError::TokenExchange
             })?;
 
@@ -188,9 +193,13 @@ impl AuthManager {
 
         let session_id = rand_str(64);
         self.sessions
-            .insert(session_id.clone(), Session::new(user_id, display_name))
+            .insert(
+                session_id.clone(),
+                Session::new(user_id.clone(), display_name),
+            )
             .await;
 
+        tracing::info!(user_id = %user_id, "login succeeded");
         Ok(session_id)
     }
 }
@@ -224,7 +233,7 @@ struct ErrorBody {
 
 impl IntoResponse for AuthError {
     fn into_response(self) -> axum::response::Response {
-        tracing::warn!(error = ?self, "authentication error");
+        tracing::warn!(error = %self, "authentication error");
 
         let (status, message) = match self {
             AuthError::UnknownProvider => (StatusCode::BAD_REQUEST, "unknown_provider"),

--- a/backend/src/auth/oidc.rs
+++ b/backend/src/auth/oidc.rs
@@ -112,20 +112,41 @@ impl OidcRegistry {
         let mut providers = HashMap::new();
 
         for (id, p) in &cfg.providers {
-            let issuer =
-                IssuerUrl::new(p.issuer.clone()).map_err(|e| OidcError::InvalidIssuer {
-                    provider: id.clone(),
-                    source: e,
-                })?;
+            let provider = Self::register_provider(id, p).await?;
+            providers.insert(id.clone(), provider);
+        }
 
-            let meta = CoreProviderMetadata::discover_async(issuer, async_http_client)
-                .await
-                .map_err(|e| OidcError::Discovery {
-                    provider: id.clone(),
-                    source: Box::new(e),
-                })?;
+        tracing::info!(
+            count = providers.len(),
+            providers = ?providers.keys().collect::<Vec<_>>(),
+            "OIDC registry initialized"
+        );
 
-            let meta = if let Some(external) = &p.external_issuer {
+        Ok(Self { providers })
+    }
+
+    /// Discover and build the client for a single OIDC provider.
+    #[tracing::instrument(skip_all, fields(provider_id = %id))]
+    async fn register_provider(
+        id: &str,
+        p: &config::OidcProvider,
+    ) -> Result<Arc<OidcProvider>, OidcError> {
+        tracing::info!(issuer = %p.issuer, "starting OIDC discovery");
+
+        let issuer = IssuerUrl::new(p.issuer.clone()).map_err(|e| OidcError::InvalidIssuer {
+            provider: id.to_string(),
+            source: e,
+        })?;
+
+        let meta = CoreProviderMetadata::discover_async(issuer, async_http_client)
+            .await
+            .map_err(|e| OidcError::Discovery {
+                provider: id.to_string(),
+                source: Box::new(e),
+            })?;
+
+        let meta =
+            if let Some(external) = &p.external_issuer {
                 let internal = p.issuer.trim_end_matches('/');
                 let external_str = external.trim_end_matches('/');
 
@@ -133,7 +154,7 @@ impl OidcRegistry {
 
                 let auth_url = AuthUrl::new(patch(meta.authorization_endpoint().as_str()))
                     .map_err(|e| OidcError::InvalidIssuer {
-                        provider: id.clone(),
+                        provider: id.to_string(),
                         source: e,
                     })?;
 
@@ -142,24 +163,22 @@ impl OidcRegistry {
                 meta
             };
 
-            let client = CoreClient::from_provider_metadata(
-                meta,
-                ClientId::new(p.client_id.clone()),
-                Some(ClientSecret::new(p.client_secret.clone())),
-            );
+        let client = CoreClient::from_provider_metadata(
+            meta,
+            ClientId::new(p.client_id.clone()),
+            Some(ClientSecret::new(p.client_secret.clone())),
+        );
 
-            if p.scopes.is_empty() {
-                return Err(OidcError::NoScopes {
-                    provider: id.clone(),
-                });
-            }
-
-            let scopes = p.scopes.iter().cloned().map(Scope::new).collect();
-
-            providers.insert(id.clone(), Arc::new(OidcProvider { client, scopes }));
+        if p.scopes.is_empty() {
+            return Err(OidcError::NoScopes {
+                provider: id.to_string(),
+            });
         }
 
-        Ok(Self { providers })
+        let scopes = p.scopes.iter().cloned().map(Scope::new).collect();
+        tracing::info!(scope_count = p.scopes.len(), "OIDC provider registered");
+
+        Ok(Arc::new(OidcProvider { client, scopes }))
     }
 
     pub fn get(&self, id: &str) -> Result<Arc<OidcProvider>, OidcError> {

--- a/backend/src/auth/session.rs
+++ b/backend/src/auth/session.rs
@@ -33,18 +33,22 @@ where
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let jar = CookieJar::from_request_parts(parts, state)
             .await
-            .map_err(|_| (StatusCode::UNAUTHORIZED, "missing cookies"))?;
+            .map_err(|_| {
+                tracing::debug!("rejected request: missing cookies");
+                (StatusCode::UNAUTHORIZED, "missing cookies")
+            })?;
 
-        let cookie = jar
-            .get("session")
-            .ok_or((StatusCode::UNAUTHORIZED, "missing session"))?;
+        let cookie = jar.get("session").ok_or_else(|| {
+            tracing::debug!("rejected request: missing session cookie");
+            (StatusCode::UNAUTHORIZED, "missing session")
+        })?;
 
         let auth = AuthManager::from_ref(state);
 
-        let session = auth
-            .get_session(cookie.value())
-            .await
-            .ok_or((StatusCode::UNAUTHORIZED, "invalid session"))?;
+        let session = auth.get_session(cookie.value()).await.ok_or_else(|| {
+            tracing::debug!("rejected request: invalid or expired session");
+            (StatusCode::UNAUTHORIZED, "invalid session")
+        })?;
 
         Ok(AuthSession(session))
     }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -39,6 +39,7 @@ async fn main() -> anyhow::Result<()> {
     let state = state::AppState::new(Db::new(pool), auth).await;
 
     let app = app::router(state);
+    tracing::info!("application initialized");
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     tracing::info!(addr = %listener.local_addr().unwrap(), "listening for connections");

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -19,12 +19,20 @@ async fn main() -> anyhow::Result<()> {
 
     logging::init_tracing(&config)?;
 
+    std::panic::set_hook(Box::new(|info| {
+        tracing::error!(panic = %info, "panic occurred");
+    }));
+
     let addr: SocketAddr = SocketAddr::new(config.listener.ip, config.listener.port);
+
     let pool = PgPool::connect(&config.database.url).await?;
+    tracing::info!("connected to database");
+
     sqlx::migrate!("./migrations")
         .run(&pool)
         .await
         .expect("Failed to apply database migrations");
+    tracing::info!("database migrations applied");
 
     let auth = AuthManager::new(&config).await?;
 
@@ -33,7 +41,7 @@ async fn main() -> anyhow::Result<()> {
     let app = app::router(state);
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
-    println!("Listening on {}", listener.local_addr().unwrap());
+    tracing::info!(addr = %listener.local_addr().unwrap(), "listening for connections");
 
     axum::serve(listener, app.into_make_service())
         .await

--- a/backend/src/rooms/manager.rs
+++ b/backend/src/rooms/manager.rs
@@ -2,6 +2,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use std::{collections::HashMap, sync::Arc};
 
 use tokio::sync::{RwLock, mpsc, watch};
+use tracing::Instrument;
 use yrs::sync::Awareness;
 use yrs::updates::decoder::Decode;
 use yrs::{Doc, ReadTxn, Subscription, Transact};
@@ -67,6 +68,7 @@ impl RoomManager {
 
     /// Aquire the [`LiveRoom`] for the `room_id` or attempt to cretate it
     /// if it doesn't already exist.
+    #[tracing::instrument(skip_all, fields(room_id = %room_id))]
     pub async fn connect(&self, room_id: &str) -> Result<Arc<LiveRoom>, Error> {
         // Check if it exists live
         let r = if let Some(r) = self.get_live(room_id).await {
@@ -81,6 +83,7 @@ impl RoomManager {
     }
 
     /// Release one connection. If it's the last we evict the room from memory
+    #[tracing::instrument(skip_all, fields(room_id = %room_id))]
     pub async fn disconnect(&self, room_id: &str) {
         let Some(room) = self.live.read().await.get(room_id).cloned() else {
             return;
@@ -97,7 +100,7 @@ impl RoomManager {
                 && Arc::ptr_eq(current, &room)
                 && current.conn_count.load(Ordering::Relaxed) == 0
             {
-                println!("Evicting room {room_id}");
+                tracing::info!("evicting room from memory (no active connections)");
                 guard.remove(room_id);
             }
         }
@@ -127,6 +130,7 @@ impl RoomManager {
 
     /// Creates a [`LiveRoom`] for the room, if it already exists return the existing
     /// [`LiveRoom`]
+    #[tracing::instrument(skip_all, fields(room_id = %room_id))]
     async fn create_room_live(&self, room_id: &str) -> Result<Arc<LiveRoom>, Error> {
         let mut guard = self.live.write().await;
         if let Some(r) = guard.get(room_id).cloned() {
@@ -174,48 +178,68 @@ impl RoomManager {
 
         let (persisted_tx, persisted_rx) = watch::channel(0u64);
 
-        tokio::spawn(async move {
-            let mut since_snapshot = 0;
-            let mut last_seq;
-            let mut processed: u64 = 0;
+        // The persistence task outlives the `create_room_live` span that spawns
+        // it, so give it its own root span rather than letting it inherit.
+        let persist_span = tracing::info_span!("room_persistence_task", room_id = %room_id_owned);
 
-            while let Some(update_bytes) = rx.recv().await {
-                match storage.append_update(&room_id_owned, &update_bytes).await {
-                    Ok(seq) => {
-                        last_seq = seq;
-                        since_snapshot += 1;
+        tokio::spawn(
+            async move {
+                let mut since_snapshot = 0;
+                let mut last_seq;
+                let mut processed: u64 = 0;
 
-                        if since_snapshot >= snapshot_every {
-                            // Encode full doc state as an update (v1) and store snapshot.
-                            let bytes = doc_for_snapshots
-                                .transact()
-                                .encode_state_as_update_v1(&yrs::StateVector::default());
+                while let Some(update_bytes) = rx.recv().await {
+                    match storage.append_update(&room_id_owned, &update_bytes).await {
+                        Ok(seq) => {
+                            last_seq = seq;
+                            since_snapshot += 1;
 
-                            let snap = storage::Snapshot {
-                                covered_through: last_seq,
-                                bytes,
-                            };
+                            if since_snapshot >= snapshot_every {
+                                // Encode full doc state as an update (v1) and store snapshot.
+                                let bytes = doc_for_snapshots
+                                    .transact()
+                                    .encode_state_as_update_v1(&yrs::StateVector::default());
 
-                            // Attempt to store snapshot. On error just log and continue.
-                            if let Err(e) = storage.store_snapshot(&room_id_owned, snap).await {
-                                eprintln!("snapshot failed room={room_id_owned}: {e:?}");
-                            } else {
-                                since_snapshot = 0;
+                                let snap = storage::Snapshot {
+                                    covered_through: last_seq,
+                                    bytes,
+                                };
+
+                                // Attempt to store snapshot. On error just log and continue.
+                                match storage.store_snapshot(&room_id_owned, snap).await {
+                                    Ok(()) => {
+                                        since_snapshot = 0;
+                                        tracing::debug!(
+                                            covered_through = last_seq,
+                                            "snapshot stored"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            error = %e,
+                                            "failed to store snapshot, will retry on next threshold"
+                                        );
+                                    }
+                                }
                             }
                         }
+                        Err(e) => {
+                            // Attempt to store change. On error just log and continue in-memory doc.
+                            tracing::error!(
+                                error = %e,
+                                "failed to persist update to storage; in-memory doc continues but change may be lost on restart"
+                            );
+                        }
                     }
-                    Err(e) => {
-                        // Attempt to store change. On error just log and continue in-memory doc.
-                        eprintln!("append_update failed room={room_id_owned}: {e:?}");
-                    }
-                }
 
-                // Mark as processed even on error: the error is already logged above and
-                // there's no retry, so this is what "drained" means for a room eviction wait.
-                processed += 1;
-                let _ = persisted_tx.send(processed);
+                    // Mark as processed even on error: the error is already logged above and
+                    // there's no retry, so this is what "drained" means for a room eviction wait.
+                    processed += 1;
+                    let _ = persisted_tx.send(processed);
+                }
             }
-        });
+            .instrument(persist_span),
+        );
 
         let enqueued = Arc::new(AtomicU64::new(0));
         let enqueued_for_sub = enqueued.clone();
@@ -226,7 +250,11 @@ impl RoomManager {
                     enqueued_for_sub.fetch_add(1, Ordering::Relaxed);
                 }
                 Err(e) => {
-                    eprintln!("room={room_id_for_sub} persist task is gone, update dropped: {e}");
+                    tracing::error!(
+                        room_id = %room_id_for_sub,
+                        error = %e,
+                        "persist task is gone, update dropped"
+                    );
                 }
             })
             .expect("Subscription function should work.");

--- a/backend/src/rooms/repo.rs
+++ b/backend/src/rooms/repo.rs
@@ -32,7 +32,13 @@ impl DatabaseStorage {
                 },
             )
             .await
-            .expect("Initialization calls should work");
+            .unwrap_or_else(|e| {
+                tracing::error!(
+                    error = %e,
+                    "failed to seed demo room during storage initialization"
+                );
+                panic!("Initialization calls should work");
+            });
 
         storage
     }

--- a/backend/src/ws/handler.rs
+++ b/backend/src/ws/handler.rs
@@ -7,17 +7,19 @@ use axum::{
 use crate::ws;
 use crate::{auth::AuthSession, state::AppState};
 
+#[tracing::instrument(skip_all, fields(room_id = %room_id, user_id = %session.user_id))]
 pub async fn ws_handler(
     AuthSession(session): AuthSession,
     ws: WebSocketUpgrade,
     Path(room_id): Path<String>,
     State(state): State<AppState>,
 ) -> impl IntoResponse {
-    println!("Request for {room_id} handler!");
+    tracing::info!("handling websocket upgrade request");
+
     let room = match state.rooms.connect(&room_id).await {
         Ok(r) => r,
         Err(e) => {
-            println!("{e:?}");
+            tracing::warn!(error = %e, "failed to connect to room");
             return StatusCode::NOT_FOUND.into_response();
         }
     };

--- a/backend/src/ws/peer.rs
+++ b/backend/src/ws/peer.rs
@@ -11,6 +11,7 @@ use yrs_axum::{
 
 use crate::rooms::RoomManager;
 
+#[tracing::instrument(skip_all, fields(room_id = %room_id))]
 pub async fn peer(ws: WebSocket, rooms: RoomManager, bcast: Arc<BroadcastGroup>, room_id: String) {
     let (sink, stream) = ws.split();
     let sink = Arc::new(Mutex::new(AxumSink::from(sink)));
@@ -28,7 +29,7 @@ pub async fn peer(ws: WebSocket, rooms: RoomManager, bcast: Arc<BroadcastGroup>,
         match DefaultProtocol.start(&awareness, &mut encoder) {
             Ok(()) => Some(encoder.to_vec()),
             Err(e) => {
-                eprintln!("room={room_id} failed to build initial sync message: {e}");
+                tracing::warn!(error = %e, "failed to build initial sync message");
                 None
             }
         }
@@ -38,14 +39,14 @@ pub async fn peer(ws: WebSocket, rooms: RoomManager, bcast: Arc<BroadcastGroup>,
     {
         let mut s = sink.lock().await;
         if let Err(e) = s.send(payload).await {
-            eprintln!("room={room_id} failed to send initial sync message: {e}");
+            tracing::warn!(error = %e, "failed to send initial sync message");
         }
     }
 
     let sub = bcast.subscribe(sink, stream);
     match sub.completed().await {
-        Ok(()) => println!("room={room_id} finished successfully"),
-        Err(e) => eprintln!("room={room_id} finished abruptly: {e}"),
+        Ok(()) => tracing::info!("websocket connection closed"),
+        Err(e) => tracing::warn!(error = %e, "websocket connection closed abnormally"),
     }
 
     rooms.disconnect(&room_id).await;


### PR DESCRIPTION
Fixes #43

Overhauls server logging so that things are logged structurally using the `tracing` crate. It also updates defaults to be more sensible for production (a bit less noisy and structured as JSON).